### PR TITLE
Added progression saving and saving states when app is put into the background

### DIFF
--- a/app/src/main/java/com/github/godspeed010/weblib/fragments/LibraryFragment.kt
+++ b/app/src/main/java/com/github/godspeed010/weblib/fragments/LibraryFragment.kt
@@ -211,12 +211,11 @@ class LibraryFragment : Fragment() {
         setGuideVisibility()
     }
 
-    override fun onStop() {
-        super.onStop()
+    override fun onPause() {
+        super.onPause()
 
         PreferencesUtils.saveFolders(activity, folders)
 
-        Log.d(TAG, "stopping")
         Log.d(TAG, "there are ${folders.size} folders ")
     }
 

--- a/app/src/main/java/com/github/godspeed010/weblib/fragments/LibraryFragment.kt
+++ b/app/src/main/java/com/github/godspeed010/weblib/fragments/LibraryFragment.kt
@@ -211,8 +211,8 @@ class LibraryFragment : Fragment() {
         setGuideVisibility()
     }
 
-    override fun onPause() {
-        super.onPause()
+    override fun onStop() {
+        super.onStop()
 
         PreferencesUtils.saveFolders(activity, folders)
 

--- a/app/src/main/java/com/github/godspeed010/weblib/fragments/NovelsFragment.kt
+++ b/app/src/main/java/com/github/godspeed010/weblib/fragments/NovelsFragment.kt
@@ -68,7 +68,8 @@ class NovelsFragment : Fragment() {
                 val action = NovelsFragmentDirections.actionNovelsFragmentToWebViewFragment(
                     url = webNovelsList[position].url,
                     novelPosition = position,
-                    folderPosition = args.position
+                    folderPosition = args.position,
+                    scrollY = webNovelsList[position].scroll
                 )
                 view.findNavController().navigate(action)
 

--- a/app/src/main/java/com/github/godspeed010/weblib/fragments/NovelsFragment.kt
+++ b/app/src/main/java/com/github/godspeed010/weblib/fragments/NovelsFragment.kt
@@ -207,9 +207,9 @@ class NovelsFragment : Fragment() {
     override fun onStop() {
         super.onStop()
 
-        Log.d(TAG, "onPause: previous novels num: ${args.folder.webNovels.size}")
+        Log.d(TAG, "onStop: previous novels num: ${args.folder.webNovels.size}")
         args.folder.webNovels = webNovelsList
-        Log.d(TAG, "onPause: new novels num: ${args.folder.webNovels.size}")
+        Log.d(TAG, "onStop: new novels num: ${args.folder.webNovels.size}")
 
         //load the old folders data
         val oldFolders = folderList

--- a/app/src/main/java/com/github/godspeed010/weblib/fragments/NovelsFragment.kt
+++ b/app/src/main/java/com/github/godspeed010/weblib/fragments/NovelsFragment.kt
@@ -63,10 +63,9 @@ class NovelsFragment : Fragment() {
                 Log.d(TAG, "onItemClicked: clicked item $position")
 
                 val action = NovelsFragmentDirections.actionNovelsFragmentToWebViewFragment(
-                    url = webNovelsList[position].url,
+                    novel = webNovelsList[position],
                     novelPosition = position,
-                    folderPosition = args.position,
-                    scrollY = webNovelsList[position].scroll
+                    folderPosition = args.position
                 )
                 view.findNavController().navigate(action)
 
@@ -205,12 +204,12 @@ class NovelsFragment : Fragment() {
         setGuideVisibility()
     }
 
-    override fun onStop() {
-        super.onStop()
+    override fun onPause() {
+        super.onPause()
 
-        Log.d(TAG, "onStop: previous novels num: ${args.folder.webNovels.size}")
+        Log.d(TAG, "onPause: previous novels num: ${args.folder.webNovels.size}")
         args.folder.webNovels = webNovelsList
-        Log.d(TAG, "onStop: new novels num: ${args.folder.webNovels.size}")
+        Log.d(TAG, "onPause: new novels num: ${args.folder.webNovels.size}")
 
         //load the old folders data
         val oldFolders = folderList

--- a/app/src/main/java/com/github/godspeed010/weblib/fragments/NovelsFragment.kt
+++ b/app/src/main/java/com/github/godspeed010/weblib/fragments/NovelsFragment.kt
@@ -204,8 +204,8 @@ class NovelsFragment : Fragment() {
         setGuideVisibility()
     }
 
-    override fun onPause() {
-        super.onPause()
+    override fun onStop() {
+        super.onStop()
 
         Log.d(TAG, "onPause: previous novels num: ${args.folder.webNovels.size}")
         args.folder.webNovels = webNovelsList

--- a/app/src/main/java/com/github/godspeed010/weblib/fragments/SearchFragment.kt
+++ b/app/src/main/java/com/github/godspeed010/weblib/fragments/SearchFragment.kt
@@ -62,7 +62,7 @@ class SearchFragment : Fragment() {
             override fun onItemClicked(position: Int) {
                 //send url, folder position, and novel position to WebViewFragment so it can save on its own
                 val action = SearchFragmentDirections
-                    .actionSearchFragmentToWebViewFragment(url = filteredList[position].url, folderPosition = filteredListIndices[position][0], novelPosition = filteredListIndices[position][1])
+                    .actionSearchFragmentToWebViewFragment(url = filteredList[position].url, folderPosition = filteredListIndices[position][0], novelPosition = filteredListIndices[position][1], scrollY = filteredList[position].scroll)
                 view.findNavController().navigate(action)
             }
 

--- a/app/src/main/java/com/github/godspeed010/weblib/fragments/SearchFragment.kt
+++ b/app/src/main/java/com/github/godspeed010/weblib/fragments/SearchFragment.kt
@@ -62,7 +62,10 @@ class SearchFragment : Fragment() {
             override fun onItemClicked(position: Int) {
                 //send url, folder position, and novel position to WebViewFragment so it can save on its own
                 val action = SearchFragmentDirections
-                    .actionSearchFragmentToWebViewFragment(url = filteredList[position].url, folderPosition = filteredListIndices[position][0], novelPosition = filteredListIndices[position][1], scrollY = filteredList[position].scroll)
+                    .actionSearchFragmentToWebViewFragment(
+                        novel = filteredList[position],
+                        folderPosition = filteredListIndices[position][0],
+                        novelPosition = filteredListIndices[position][1])
                 view.findNavController().navigate(action)
             }
 

--- a/app/src/main/java/com/github/godspeed010/weblib/fragments/WebViewFragment.kt
+++ b/app/src/main/java/com/github/godspeed010/weblib/fragments/WebViewFragment.kt
@@ -103,9 +103,7 @@ class WebViewFragment : Fragment() {
                 Log.d(TAG, "URL CHANGE to $url")
 
                 //Update address bar
-                view.apply {
-                    findViewById<EditText>(R.id.et_address_bar).setText(url)
-                }
+                view.findViewById<EditText>(R.id.et_address_bar).setText(url)
                 pageError = false
 
                 if (url != null && lastVisitedUrl != url) {
@@ -130,10 +128,7 @@ class WebViewFragment : Fragment() {
                 if ((loadedUrl == novel.url) && !pageError && lastProgression != 0f) {
                     scrollWebView(lastProgression, wv)
                 } else {
-                    view.apply {
-                        val progressBar = findViewById<View>(R.id.progressView)
-                        progressBar.visibility = View.GONE
-                    }
+                    view.findViewById<View>(R.id.progressView).visibility = View.GONE
                 }
             }
         }

--- a/app/src/main/java/com/github/godspeed010/weblib/fragments/WebViewFragment.kt
+++ b/app/src/main/java/com/github/godspeed010/weblib/fragments/WebViewFragment.kt
@@ -103,7 +103,9 @@ class WebViewFragment : Fragment() {
                 Log.d(TAG, "URL CHANGE to $url")
 
                 //Update address bar
-                requireView().findViewById<EditText>(R.id.et_address_bar).setText(url)
+                view.apply {
+                    findViewById<EditText>(R.id.et_address_bar).setText(url)
+                }
                 pageError = false
 
                 if (url != null && lastVisitedUrl != url) {

--- a/app/src/main/java/com/github/godspeed010/weblib/fragments/WebViewFragment.kt
+++ b/app/src/main/java/com/github/godspeed010/weblib/fragments/WebViewFragment.kt
@@ -36,7 +36,6 @@ import kotlin.properties.Delegates
 
 class WebViewFragment : Fragment() {
 
-    private var timer: Timer? = null
     private val TAG = "WebViewFragment"
 
     lateinit var mainToolbar: MaterialToolbar
@@ -138,8 +137,6 @@ class WebViewFragment : Fragment() {
             webView.setOnScrollChangeListener { view, _, _, _, _ ->
                 updateProgression()
             }
-        } else {
-            startTimer()
         }
 
         webView.webViewClient = mWebViewClient
@@ -254,44 +251,6 @@ class WebViewFragment : Fragment() {
         shareIntent.type = "text/plain"
         shareIntent.putExtra(Intent.EXTRA_TEXT, url)
         startActivity(Intent.createChooser(shareIntent, "Share This Website!"))
-    }
-
-    private fun startTimer() {
-        if (timer != null) return
-
-        Log.d(TAG, "Starting timer for tracking progression")
-
-        timer = Timer()
-        timer!!.scheduleAtFixedRate(object : TimerTask() {
-            override fun run() {
-                requireActivity().runOnUiThread { updateProgression() }
-            }
-        }, 10000, 10000)
-    }
-
-    private fun stopTimer() {
-        if (timer == null) return
-
-        Log.d(TAG, "Stopping timer for tracking progression")
-
-        timer!!.cancel()
-        timer = null
-    }
-
-    override fun onPause() {
-        super.onPause()
-
-        if (timer != null) updateProgression()
-
-        stopTimer()
-    }
-
-    override fun onResume() {
-        super.onResume()
-
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-            startTimer()
-        }
     }
 
     override fun onStop() {

--- a/app/src/main/java/com/github/godspeed010/weblib/fragments/WebViewFragment.kt
+++ b/app/src/main/java/com/github/godspeed010/weblib/fragments/WebViewFragment.kt
@@ -1,12 +1,9 @@
 package com.github.godspeed010.weblib.fragments
 
-import android.content.Context
-import android.content.SharedPreferences
 import android.os.Bundle
 import android.util.Log
 import android.util.Patterns
 import android.view.*
-import android.view.inputmethod.InputMethodManager
 import androidx.fragment.app.Fragment
 import android.webkit.WebView
 import android.webkit.WebViewClient
@@ -30,17 +27,18 @@ import android.content.res.Configuration
 import android.os.Build
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
-import androidx.core.view.forEach
-import androidx.core.view.forEachIndexed
+import android.widget.Toast
 import com.github.godspeed010.weblib.R
 import com.github.godspeed010.weblib.hideKeyboard
+import com.github.godspeed010.weblib.models.WebNovel
 import com.github.godspeed010.weblib.preferences.PreferencesUtils
+import java.text.NumberFormat
 import java.util.*
-
 
 class WebViewFragment : Fragment() {
 
     private val TAG = "WebViewFragment"
+    private var timer: Timer? = null
 
     lateinit var mainToolbar: MaterialToolbar
     lateinit var webViewToolbar: Toolbar
@@ -49,11 +47,12 @@ class WebViewFragment : Fragment() {
     lateinit var mAdView: AdView
     lateinit var webView: WebView
     lateinit var lastVisitedUrl: String
-    lateinit var timer: Timer
+    lateinit var lastPageTitle: String
 
-    var lastScroll by Delegates.notNull<Int>()
+    var lastProgression by Delegates.notNull<Float>()
     var novelPosition by Delegates.notNull<Int>()
     var folderPosition by Delegates.notNull<Int>()
+    var pageError by Delegates.notNull<Boolean>()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         // Inflate the layout for this fragment
@@ -61,12 +60,16 @@ class WebViewFragment : Fragment() {
 
         navHostFragment = (activity as AppCompatActivity).supportFragmentManager.findFragmentById(R.id.nav_host_fragment) as NavHostFragment
 
-        val url: String = WebViewFragmentArgs.fromBundle(requireArguments()).url
+        val novel: WebNovel = WebViewFragmentArgs.fromBundle(requireArguments()).novel
         novelPosition = WebViewFragmentArgs.fromBundle(requireArguments()).novelPosition
         folderPosition = WebViewFragmentArgs.fromBundle(requireArguments()).folderPosition
 
-        lastVisitedUrl = url
-        lastScroll = WebViewFragmentArgs.fromBundle(requireArguments()).scrollY
+        // set lastVisitedUrl and lastScroll to their original values.
+        // Prevents crashing if user returns from WebView before it's loaded
+        lastVisitedUrl = novel.url
+        lastProgression = novel.progression
+
+        Log.d(TAG, "density=${resources.displayMetrics.density}, densityDpi=${resources.displayMetrics.densityDpi}")
 
         setHasOptionsMenu(true)
 
@@ -84,10 +87,9 @@ class WebViewFragment : Fragment() {
 
         webView.settings.javaScriptEnabled = true
 
-        webView.loadUrl(url)
+        webView.loadUrl(novel.url)
 
         val mWebViewClient: WebViewClient = object : WebViewClient() {
-            private var pageError = false
             //called every time URL changes
             override fun doUpdateVisitedHistory(wv: WebView?, url: String?, isReload: Boolean) {
                 super.doUpdateVisitedHistory(wv, url, isReload)
@@ -99,7 +101,8 @@ class WebViewFragment : Fragment() {
                     view.findViewById<EditText>(R.id.et_address_bar).setText(url)
 
                     if (url != null) {
-                        lastScroll = 0
+                        pageError = false
+                        lastProgression = 0f
                         lastVisitedUrl = url
                     }
                 }
@@ -108,21 +111,49 @@ class WebViewFragment : Fragment() {
             override fun onReceivedHttpError(wv: WebView?, request: WebResourceRequest?, errorResponse: WebResourceResponse?) {
                 super.onReceivedHttpError(wv, request, errorResponse)
 
-                pageError = true
+                if (request?.url.toString() == wv?.url) pageError = true
             }
 
-            override fun onPageFinished(wv: WebView?, url: String?) {
-                super.onPageFinished(wv, url)
+            override fun onPageFinished(wv: WebView?, loadedUrl: String?) {
+                super.onPageFinished(wv, loadedUrl)
 
-                if (url == WebViewFragmentArgs.fromBundle(requireArguments()).url && !pageError) {
-                    wv!!.scrollTo(0, WebViewFragmentArgs.fromBundle(requireArguments()).scrollY)
+                if ((loadedUrl == novel.url) && !pageError) {
+                    if (novel.progression != 0f) {
+                        val toast: Toast = Toast.makeText(context, "Please wait for page to scroll.", Toast.LENGTH_LONG)
+                        toast.show()
+                        wv?.postDelayed({
+                            val scrollY: Int = calculateScrollYFromProgression(novel.progression, wv)
+                            val progressionPct: String = NumberFormat.getPercentInstance().let {
+                                it.minimumFractionDigits = 1
+                                it.format(novel.progression)
+                            }
+                            Log.d(
+                                TAG,
+                                "Page finished loading, scrolling to $scrollY ($progressionPct)"
+                            )
+                            wv.scrollTo(0, scrollY)
+                            toast.cancel()
+                        }, 2000)
+                    }
                 }
+
+                lastPageTitle = wv?.title ?: loadedUrl!!
             }
         }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             webView.setOnScrollChangeListener { view, _, _, _, _ ->
-                lastScroll = view.scrollY
+                if (!pageError) {
+                    lastProgression = calculateProgression(webView)
+                    val progressionPct: String = NumberFormat.getPercentInstance().let {
+                        it.minimumFractionDigits = 1
+                        it.format(lastProgression)
+                    }
+                    Log.v(
+                        TAG,
+                        "Page progression is now $progressionPct"
+                    )
+                }
             }
         }
 
@@ -167,26 +198,20 @@ class WebViewFragment : Fragment() {
         val adRequest = AdRequest.Builder().build()
         mAdView.loadAd(adRequest)
 
-        timer = Timer("AutoSave")
-        timer.scheduleAtFixedRate(object : TimerTask() {
-            override fun run() {
-                overwriteSave(lastVisitedUrl, lastScroll)
-            }
-        }, 30000, 30000)
-
         return view
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         inflater.inflate(R.menu.menu_toolbar_webview, menu)
         if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) {
+            // Automatically turn on dark mode if night mode on the device is active.
             if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && resources.configuration.isNightModeActive) ||
                 (resources.configuration.uiMode.and(Configuration.UI_MODE_NIGHT_MASK)) == Configuration.UI_MODE_NIGHT_YES
             ) {
                 menu.findItem(R.id.dark_mode).isChecked = true
                 WebSettingsCompat.setForceDark(webView.settings, WebSettingsCompat.FORCE_DARK_ON)
             }
-        } else {
+        } else { // If forcing dark mode is not supported by the web view, hide the option to enable dark mode.
             menu.findItem(R.id.dark_mode).isVisible = false
         }
         return super.onCreateOptionsMenu(menu, inflater)
@@ -202,17 +227,41 @@ class WebViewFragment : Fragment() {
         return super.onOptionsItemSelected(item)
     }
 
-    override fun onStop() {
-        super.onStop()
-
-        timer.cancel()
-    }
-
     private fun shareUrl(url: String?) {
         val shareIntent = Intent(Intent.ACTION_SEND)
         shareIntent.type = "text/plain"
         shareIntent.putExtra(Intent.EXTRA_TEXT, url)
         startActivity(Intent.createChooser(shareIntent, "Share This Website!"))
+    }
+
+    override fun onPause() {
+        super.onPause()
+
+        overwriteSave()
+
+        stopTimer()
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        startTimer()
+    }
+
+    private fun startTimer() {
+        if (timer != null) return
+        timer = Timer("AutoSave")
+        timer!!.scheduleAtFixedRate(object : TimerTask() {
+            override fun run() {
+                overwriteSave()
+            }
+        }, 30000, 30000)
+    }
+
+    private fun stopTimer() {
+        if (timer == null) return
+        timer!!.cancel()
+        timer = null
     }
 
     private fun toggleDarkMode(item: MenuItem) {
@@ -263,14 +312,24 @@ class WebViewFragment : Fragment() {
         bottomNav.visibility = visibility
     }
 
-    fun overwriteSave(url: String, scrollY: Int) {
+    fun overwriteSave() {
         val folders = PreferencesUtils.loadFolders(activity)
 
         //update the url for the novel
-        folders[folderPosition].webNovels[novelPosition].url = url
-        folders[folderPosition].webNovels[novelPosition].scroll = scrollY
+        folders[folderPosition].webNovels[novelPosition].url = lastVisitedUrl
+        folders[folderPosition].webNovels[novelPosition].progression = lastProgression
 
         //save the updated data
         PreferencesUtils.saveFolders(activity, folders)
+        Log.d(TAG, "Web Novel saved!")
+    }
+
+    private fun calculateProgression(wv: WebView): Float {
+        // The 200 subtracted is to bring a little bit above where a user stopped so they can determine where they were again.
+        return ((wv.scrollY - wv.top - 200).toFloat() / resources.displayMetrics.density) / wv.contentHeight
+    }
+
+    private fun calculateScrollYFromProgression(progression: Float, wv: WebView): Int {
+        return ((progression * wv.contentHeight) * resources.displayMetrics.density).toInt() + wv.top
     }
 }

--- a/app/src/main/java/com/github/godspeed010/weblib/fragments/WebViewFragment.kt
+++ b/app/src/main/java/com/github/godspeed010/weblib/fragments/WebViewFragment.kt
@@ -320,8 +320,11 @@ class WebViewFragment : Fragment() {
         val folders = PreferencesUtils.loadFolders(activity)
 
         //update the url for the novel
-        folders[folderPosition].webNovels[novelPosition].url = lastVisitedUrl
-        folders[folderPosition].webNovels[novelPosition].progression = lastProgression
+        val currentNovel = folders[folderPosition].webNovels[novelPosition]
+        currentNovel.apply {
+            url = lastVisitedUrl
+            progression = lastProgression
+        }
 
         //save the updated data
         PreferencesUtils.saveFolders(activity, folders)

--- a/app/src/main/java/com/github/godspeed010/weblib/models/WebNovel.kt
+++ b/app/src/main/java/com/github/godspeed010/weblib/models/WebNovel.kt
@@ -9,5 +9,5 @@ import kotlinx.android.parcel.Parcelize
 data class WebNovel (
     var title: String = "",
     var url: String = "",
-    var scroll: Int = 0
-    ): Parcelable
+    var progression: Float = 0f
+): Parcelable

--- a/app/src/main/java/com/github/godspeed010/weblib/models/WebNovel.kt
+++ b/app/src/main/java/com/github/godspeed010/weblib/models/WebNovel.kt
@@ -8,5 +8,6 @@ import kotlinx.android.parcel.Parcelize
 @Parcelize
 data class WebNovel (
     var title: String = "",
-    var url: String = ""
+    var url: String = "",
+    var scroll: Int = 0
     ): Parcelable

--- a/app/src/main/java/com/github/godspeed010/weblib/preferences/FolderTypeAdapter.kt
+++ b/app/src/main/java/com/github/godspeed010/weblib/preferences/FolderTypeAdapter.kt
@@ -57,6 +57,7 @@ class FolderTypeAdapter: TypeAdapter<Folder>() {
 
                         reader.endArray()
                     }
+                    else -> reader.skipValue()
                 }
             } catch(err: Error) {}
         }

--- a/app/src/main/java/com/github/godspeed010/weblib/preferences/WebNovelTypeAdapter.kt
+++ b/app/src/main/java/com/github/godspeed010/weblib/preferences/WebNovelTypeAdapter.kt
@@ -18,8 +18,8 @@ class WebNovelTypeAdapter: TypeAdapter<WebNovel>() {
         writer.name("url")
         writer.value(value.url)
 
-        writer.name("scroll")
-        writer.value(value.scroll)
+        writer.name("progression")
+        writer.value(value.progression.toDouble())
 
         writer.endObject()
     }
@@ -40,7 +40,8 @@ class WebNovelTypeAdapter: TypeAdapter<WebNovel>() {
             {
                 "title" -> novel.title = reader.nextString()
                 "url" -> novel.url = reader.nextString()
-                "scroll" -> novel.scroll = reader.nextInt()
+                "progression" -> novel.progression = reader.nextDouble().toFloat()
+                else -> reader.skipValue()
             }
         }
 

--- a/app/src/main/java/com/github/godspeed010/weblib/preferences/WebNovelTypeAdapter.kt
+++ b/app/src/main/java/com/github/godspeed010/weblib/preferences/WebNovelTypeAdapter.kt
@@ -8,19 +8,24 @@ import com.github.godspeed010.weblib.models.WebNovel
 
 class WebNovelTypeAdapter: TypeAdapter<WebNovel>() {
     override fun write(writer: JsonWriter, value: WebNovel?) {
+        if(value == null) return;
+
         writer.beginObject()
 
         writer.name("title")
-        writer.value(value?.title)
+        writer.value(value.title)
 
         writer.name("url")
-        writer.value(value?.url)
+        writer.value(value.url)
+
+        writer.name("scroll")
+        writer.value(value.scroll)
 
         writer.endObject()
     }
 
     override fun read(reader: JsonReader): WebNovel {
-        var novel: WebNovel = WebNovel()
+        var novel = WebNovel()
 
         if(reader.peek() == JsonToken.NULL)
         {
@@ -31,11 +36,11 @@ class WebNovelTypeAdapter: TypeAdapter<WebNovel>() {
         reader.beginObject()
 
         while(reader.hasNext()) {
-            val name = reader.nextName()
-            when(name)
+            when(reader.nextName())
             {
                 "title" -> novel.title = reader.nextString()
                 "url" -> novel.url = reader.nextString()
+                "scroll" -> novel.scroll = reader.nextInt()
             }
         }
 

--- a/app/src/main/res/layout/fragment_web_view.xml
+++ b/app/src/main/res/layout/fragment_web_view.xml
@@ -49,4 +49,22 @@
         app:adSize="BANNER"
         app:adUnitId="@string/banner_ad_unit_id" />
 
+    <RelativeLayout
+        android:id="@+id/progressView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:alpha="0.5"
+        android:background="#000000"
+        android:clickable="true"
+        android:focusable="true"
+        android:visibility="visible">
+
+        <ProgressBar
+            android:id="@+id/progressBar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_centerInParent="true"
+            android:contentDescription="Please wait" />
+    </RelativeLayout>
+
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -32,17 +32,14 @@
         android:name="com.github.godspeed010.weblib.fragments.WebViewFragment"
         tools:layout="@layout/fragment_web_view" >
         <argument
-            android:name="url"
-            app:argType="string" />
-        <argument
             android:name="folderPosition"
             app:argType="integer" />
         <argument
             android:name="novelPosition"
             app:argType="integer" />
         <argument
-            android:name="scrollY"
-            app:argType="integer" />
+            android:name="novel"
+            app:argType="com.github.godspeed010.weblib.models.WebNovel" />
 
     </fragment>
     <fragment

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -40,6 +40,9 @@
         <argument
             android:name="novelPosition"
             app:argType="integer" />
+        <argument
+            android:name="scrollY"
+            app:argType="integer" />
 
     </fragment>
     <fragment


### PR DESCRIPTION
This PR adds an auto-save feature that will save your progress locally every 30 seconds, as well as changes so that when the app is paused (unfocused, no longer the main activity open), it will save locally instead of only saving when the app is stopped, as the app may be killed by another process starting up before it has time to save data.

In addition, this PR also adds functionality to save scroll progress on a chapter. So if you stop mid-chapter, and then come back later, your point in the chapter will not be lost if the app is fully stopped.