### PR TITLE
Bug fix for crashing upon leaving a novel too quickly after opening it

### DIFF
--- a/app/src/main/java/com/github/godspeed010/weblib/fragments/WebViewFragment.kt
+++ b/app/src/main/java/com/github/godspeed010/weblib/fragments/WebViewFragment.kt
@@ -209,8 +209,7 @@ class WebViewFragment : Fragment() {
         progressBar.visibility = View.VISIBLE
         wv?.postDelayed({
             // Fragment has been closed, no need to scroll web view anymore.
-            if(context == null)
-                return@postDelayed;
+            if (context == null) return@postDelayed
 
             val scrollY: Int = calculateScrollYFromProgression(progression, wv)
             val progressionPct: String = NumberFormat.getPercentInstance().let {

--- a/app/src/main/java/com/github/godspeed010/weblib/fragments/WebViewFragment.kt
+++ b/app/src/main/java/com/github/godspeed010/weblib/fragments/WebViewFragment.kt
@@ -202,8 +202,7 @@ class WebViewFragment : Fragment() {
 
     private fun scrollWebView(progression: Float, wv: WebView?) {
         // Fragment has been closed, no need to scroll web view anymore.
-        if(view == null)
-            return;
+        if (view == null) return
 
         val progressBar = requireView().findViewById<View>(R.id.progressView)
 

--- a/app/src/main/java/com/github/godspeed010/weblib/fragments/WebViewFragment.kt
+++ b/app/src/main/java/com/github/godspeed010/weblib/fragments/WebViewFragment.kt
@@ -201,10 +201,18 @@ class WebViewFragment : Fragment() {
     }
 
     private fun scrollWebView(progression: Float, wv: WebView?) {
+        // Fragment has been closed, no need to scroll web view anymore.
+        if(view == null)
+            return;
+
         val progressBar = requireView().findViewById<View>(R.id.progressView)
 
         progressBar.visibility = View.VISIBLE
         wv?.postDelayed({
+            // Fragment has been closed, no need to scroll web view anymore.
+            if(context == null)
+                return@postDelayed;
+
             val scrollY: Int = calculateScrollYFromProgression(progression, wv)
             val progressionPct: String = NumberFormat.getPercentInstance().let {
                 it.minimumFractionDigits = 1


### PR DESCRIPTION
I believe this fixes an issue where if you leave a novel too soon after opening it (before the loading icon goes away) it will crash the app. Going to check for anywhere else that needs to check that the view or context still exists, in case this issue is prevalent elsewhere.